### PR TITLE
ci(workflow): split web-ci into lint/build/test

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -2,9 +2,12 @@ name: Web CI
 
 on:
   pull_request:
+    branches: [main]
+    # Ensure CI runs when workflows or web code change so PRs that modify CI are validated
     paths:
       - 'web/**'
       - 'package.json'
+      - '.github/**'
   push:
     branches: [main]
     paths:
@@ -12,8 +15,8 @@ on:
       - 'package.json'
 
 jobs:
-  build:
-    name: Build and Lint web
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,25 +28,51 @@ jobs:
           node-version: '18'
           cache: 'npm'
 
-      - name: Cache npm
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json','**/web/package-lock.json','**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
         run: npm ci
 
       - name: Lint web workspace
         run: npm --workspace=web run lint
 
-      - name: Typecheck web workspace
-        run: npm --workspace=web run typecheck
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build web workspace
         run: npm --workspace=web run build
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck web workspace
+        run: npm --workspace=web run typecheck
 
       - name: Start web server
         run: |


### PR DESCRIPTION
Split web-ci into lint/build/test and include .github/** triggers

- Produces check contexts: lint, build, test
- Ensures workflow edits run CI
