### PR TITLE
ci: fix web-ci workflow pull_request trigger

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -2,6 +2,7 @@ name: Web CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - 'web/**'
       - 'package.json'


### PR DESCRIPTION
This PR fixes a parsing/trigger issue in `.github/workflows/web-ci.yml` that prevented the Web CI from running on PRs.

What I changed:
- Added explicit `pull_request` event `types: [opened, synchronize, reopened]` so GitHub matches PR events reliably.

Why:
- The malformed/implicit configuration on `develop` prevented PR-triggered runs, so other PRs (including the M1 PR) were not receiving the Web CI checks. Merging this will allow PRs to trigger the Web CI pipeline.

This is a small, safe change. Opening as a draft so we can review before merging.
