### PR TITLE
ci: gate Playwright tests on secret-check output (non-fatal)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -55,6 +55,7 @@ jobs:
         uses: microsoft/playwright-github-action@v1
 
       - name: Verify required secrets
+        id: verify_secrets
         env:
           SANITY_PREVIEW_SECRET: ${{ secrets.SANITY_PREVIEW_SECRET }}
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
@@ -69,13 +70,19 @@ jobs:
               missing="$missing $v"
             fi
           done
+          # Trim leading space
+          missing="${missing## }"
+          echo "missing=$missing" >> $GITHUB_OUTPUT
           if [ -n "$missing" ]; then
-            echo "\nERROR: The following required secrets are missing:$missing\n"
-            echo "Please add them in GitHub → Settings → Secrets and variables → Actions. See .github/README_SECRETS.md"
-            exit 1
+            echo "The following required secrets are missing: $missing"
+            echo "secrets_ok=false" >> $GITHUB_OUTPUT
+          else
+            echo "All required secrets present"
+            echo "secrets_ok=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run Playwright smoke tests
+        if: steps.verify_secrets.outputs.secrets_ok == 'true'
         env:
           SANITY_PREVIEW_SECRET: ${{ secrets.SANITY_PREVIEW_SECRET }}
           NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}


### PR DESCRIPTION
Make the required-secrets check non-fatal and expose an output (secrets_ok). This allows build/typecheck/lint to run on PRs even when repository secrets are missing; Playwright and token-minting steps remain gated on secrets_ok.\n\nLinked: #33\n\nThis change is safe to merge and improves CI feedback for contributors who don't have repo secrets configured locally or in forks.